### PR TITLE
Implement the submit mode of getblocktemplate.

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -527,7 +527,6 @@ Value getblocktemplate(const Array& params, bool fHelp)
         CBlock pblock;
         ssBlock >> pblock;
 
-        return ProcessBlock(NULL, &pblock);
         bool fAccepted = ProcessBlock(NULL, &pblock);
 
         return fAccepted ? Value::null : "rejected";


### PR DESCRIPTION
This patch implements the submit mode to getblocktemplate, often used by stratum servers instead of submitblock.
